### PR TITLE
Remove call to sys.exit

### DIFF
--- a/della/hf_model_downloader.py
+++ b/della/hf_model_downloader.py
@@ -54,5 +54,3 @@ def main():
 
 if __name__=='__main__':
     main()
-    exit(0)
-


### PR DESCRIPTION
Also did not seem to be defined (but scripts exit with `0` anyway)